### PR TITLE
Allow for the absence of an old version

### DIFF
--- a/bin/npm-release
+++ b/bin/npm-release
@@ -43,10 +43,9 @@ var getCurrentVersion = function () {
   return getPkg().version;
 };
 
-var oldVersion = getCurrentVersion(),
+var oldVersion = getCurrentVersion() || '[no version]',
     message = argv.m || argv.message;
 
-if (!oldVersion) error('No version in package.json found.');
 if (!version) error('No version supplied.');
 
 // Run npm verison (tags & commits)


### PR DESCRIPTION
If you're publishing a package for the first time, you won't have a version yet.
