### PR TITLE
Add support for publishing to an organization

### DIFF
--- a/bin/npm-release
+++ b/bin/npm-release
@@ -75,11 +75,18 @@ npm.on('close', function (code) {
       msg('Publish to npm cancelled, this is a private repo.');
       return done();
     }
-
-    msg('Publishing to npm...');
+      
+    var args = ['publish'];
+      
+    if (getPkg().name[0] === '@') {
+      msg('Detected ' + getPkg().name.match(/^@\w+/)[0]);
+      args.push('--access', 'public');
+    }
+      
+    msg('Publishing publicly to npm...');
 
     // Publish to npm
-    var publish = spawn('npm', ['publish']);
+    var publish = spawn('npm', args);
     publish.stdout.pipe(process.stdout);
     publish.stderr.pipe(process.stderr);
     publish.on('close', function (code) {


### PR DESCRIPTION
I use this tool often because it's so simple to use, however it does not allow to publish to an organization because `npm publish` defaults to private for organizations.

This pull request automatically adds `--access public` if the package is from an organization.

See: https://www.npmjs.com/docs/orgs/publishing-an-org-scoped-package.html#publishing-a-public-scoped-package
